### PR TITLE
Changed acf_register_block to acf_register_block_type

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -3,7 +3,7 @@
 namespace App;
 
 // Check whether WordPress and ACF are available; bail if not.
-if (! function_exists('acf_register_block')) {
+if (! function_exists('acf_register_block_type')) {
     return;
 }
 if (! function_exists('add_filter')) {
@@ -103,7 +103,7 @@ add_action('acf/init', function () {
                 }
 
                 // Register the block with ACF
-                \acf_register_block($data);
+                \acf_register_block_type($data);
             }
         }
     }


### PR DESCRIPTION
In 5.8.0 beta 3 `acf_register_block_type` was added - I think we should use this name to keep the naming more compatible with WP - https://developer.wordpress.org/reference/functions/register_block_type/