### PR TITLE
Pass along is_preview and content to template

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -127,6 +127,8 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
 
     // Set up the block data
     $block['post_id'] = $post_id;
+    $block['is_preview'] = $is_preview;
+    $block['content'] = $content;
     $block['slug'] = $slug;
     $block['classes'] = implode(' ', [$block['slug'], $block['className'], 'align'.$block['align']]);
 


### PR DESCRIPTION
ACF has some logic to determine if the template is being rendered to the editor vs the frontend (is_preview) and also a `$content` variable, which I'm not entirely sure of the purpose of at this point, but figured it should be passed along as well while we're at it.