### PR TITLE
Verify files have correct .blade.php extension before attempting to register blocks.

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -31,7 +31,6 @@ add_action('acf/init', function () {
 
     // Check whether ACF exists before continuing
     foreach ($directories as $dir) {
-
         // Sanity check whether the directory we're iterating over exists first
         if (!file_exists(\locate_template($dir))) {
             return;
@@ -42,9 +41,13 @@ add_action('acf/init', function () {
 
         foreach ($template_directory as $template) {
             if (!$template->isDot() && !$template->isDir()) {
-
-            // Strip the file extension to get the slug
+                // Strip the file extension to get the slug
                 $slug = removeBladeExtension($template->getFilename());
+                // If there is no slug (most likely because the filename does
+                // not end with ".blade.php", move on to the next file.
+                if (!$slug) {
+                    continue;
+                }
 
                 // Get header info from the found template file(s)
                 $file_path = locate_template($dir."/${slug}.blade.php");
@@ -128,7 +131,7 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
     // Set up the block data
     $block['post_id'] = $post_id;
     $block['slug'] = $slug;
-    $block['classes'] = implode(' ', [$block['slug'], $block['className'], 'align'.$block['align']]);
+    $block['classes'] = implode(' ', array_filter([$block['slug'], $block['className'], 'align'.$block['align']]));
 
     // Use Sage's template() function to echo the block and populate it with data
     echo \App\template("blocks/${slug}", ['block' => $block]);
@@ -139,10 +142,13 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
  */
 function removeBladeExtension($filename)
 {
-
-  // Remove the unwanted extensions
-    $return = substr($filename, 0, strrpos($filename, '.blade.php'));
-
-    // Always return
-    return $return;
+    // Filename must end with ".blade.php". Parenthetical captures the slug.
+    $blade_pattern = '/(.*)\.blade\.php$/';
+    $matches = [];
+    // If the filename matches the pattern, return the slug.
+    if (preg_match($blade_pattern, $filename, $matches)) {
+        return $matches[1];
+    }
+    // Return FALSE if the filename doesn't match the pattern.
+    return FALSE;
 }

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -131,7 +131,7 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
     // Set up the block data
     $block['post_id'] = $post_id;
     $block['slug'] = $slug;
-    $block['classes'] = implode(' ', array_filter([$block['slug'], $block['className'], 'align'.$block['align']]));
+    $block['classes'] = implode(' ', [$block['slug'], $block['className'], 'align'.$block['align']]);
 
     // Use Sage's template() function to echo the block and populate it with data
     echo \App\template("blocks/${slug}", ['block' => $block]);


### PR DESCRIPTION
This should fix MWDelaney/sage-acf-wp-blocks#11.

I also added a bit of tidying for the classes array, which had extra spaces if `className` was empty.