### PR TITLE
Default align

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -95,6 +95,7 @@ add_action('acf/init', function () {
                     'icon' => $file_headers['icon'],
                     'keywords' => explode(' ', $file_headers['keywords']),
                     'mode' => $file_headers['mode'],
+                    'align' => $file_headers['align'],
                     'render_callback'  => __NAMESPACE__.'\\sage_blocks_callback',
                     'enqueue_style'   => $file_headers['enqueue_style'],
                     'enqueue_script'  => $file_headers['enqueue_script'],


### PR DESCRIPTION
Default alignment wasn't getting passed along to acf_register_block_type, now it is.