### PR TITLE
Make sure anchor is always et

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -154,6 +154,7 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
     $block['is_preview'] = $is_preview;
     $block['content'] = $content;
     $block['slug'] = $slug;
+    $block['anchor'] = isset($block['anchor']) ? $block['anchor'] : '';
     // Send classes as array to filter for easy manipulation.
     $block['classes'] = [
         $slug,


### PR DESCRIPTION
make sure that $block['anchor'] is always set, so we can just use {{ ['anchor'] }} without any checks