### PR TITLE
Register block data filter

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -133,7 +133,7 @@ add_action('acf/init', function () {
                 }
 
                 // Register the block with ACF
-                \acf_register_block_type($data);
+                \acf_register_block_type( apply_filters( "sage/blocks/$slug/register-data", $data ) );
             }
         }
     }


### PR DESCRIPTION
In order to create ACF blocks with innerBlocks Gutenberg functionality I need to filter the $data array to add an entry named has_inner_blocks. I'm following this gist https://gist.github.com/gaambo/633bcd83a9596762218ffa65d0cfe22a and it works like a charm, but I need to show inner blocks in the editor inside ACF HTML output.

With this change I can call the hook to add $data['has_inner_blocks'] = true; for that container block. I'm doing sth like @terence1990 comment here:
https://gist.github.com/gaambo/633bcd83a9596762218ffa65d0cfe22a#gistcomment-3182473

Code tested and works but change the hook name as you want ;D