### PR TITLE
Fix #45: Template location mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ Block data can be altered via the 'sage/blocks/[block-name]/data' filter. For ex
 ```php
 add_filter('sage/blocks/my-block/data', function ($block) { // Do your thing here. });
 ```
+
+## Filter template folders
+By default all your template files in `views/blocks` will be loaded. You can use the templates filter to add more folders if you wish. See an example below of how to add your own folders.
+
+```php
+add_filter('sage-acf-gutenberg-blocks-templates', function ($folders) { 
+    $folders[] = 'views/your-folder'; // Adds your folder
+    return $folders;
+});
+```

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -32,16 +32,16 @@ add_action('acf/init', function () {
     $directories = apply_filters('sage-acf-gutenberg-blocks-templates', []);
 
     // Check whether ACF exists before continuing
-    foreach ($directories as $dir) {
-        $directory = isSage10() ? \Roots\resource_path($dir) : \locate_template($dir);
+    foreach ($directories as $directory) {
+        $dir = isSage10() ? \Roots\resource_path($directory) : \locate_template($directory);
 
         // Sanity check whether the directory we're iterating over exists first
-        if (!file_exists($directory)) {
+        if (!file_exists($dir)) {
             return;
         }
 
         // Iterate over the directories provided and look for templates
-        $template_directory = new \DirectoryIterator($directory);
+        $template_directory = new \DirectoryIterator($dir);
 
         foreach ($template_directory as $template) {
             if (!$template->isDot() && !$template->isDir()) {
@@ -55,7 +55,7 @@ add_action('acf/init', function () {
                 }
 
                 // Get header info from the found template file(s)
-                $file = "${$directory}/${slug}.blade.php";
+                $file = "${dir}/${slug}.blade.php";
                 $file_path = file_exists($file) ? $file : '';
                 $file_headers = get_file_data($file_path, [
                     'title' => 'Title',
@@ -183,7 +183,7 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
 
         } else {
             // Use Sage 9's template() function to echo the block and populate it with data
-            echo \App\template("{$directory}/${slug}", ['block' => $block]);
+            echo \App\template("${directory}/${slug}", ['block' => $block]);
         }
     }
 }

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use Illuminate\Support\Str;
+
 // Check whether WordPress and ACF are available; bail if not.
 if (! function_exists('acf_register_block_type')) {
     return;
@@ -15,11 +17,7 @@ if (! function_exists('add_action')) {
 
 // Add the default blocks location, 'views/blocks', via filter
 add_filter('sage-acf-gutenberg-blocks-templates', function () {
-    $blocksDir = 'views/blocks';
-    if (isSage10()) {
-        $blocksDir = "resources/$blocksDir";
-    }
-    return array($blocksDir);
+    return ['views/blocks'];
 });
 
 /**
@@ -35,13 +33,15 @@ add_action('acf/init', function () {
 
     // Check whether ACF exists before continuing
     foreach ($directories as $dir) {
+        $directory = isSage10() ? \Roots\resource_path($dir) : \locate_template($dir);
+
         // Sanity check whether the directory we're iterating over exists first
-        if (!file_exists(\locate_template($dir))) {
+        if (!file_exists($directory)) {
             return;
         }
 
         // Iterate over the directories provided and look for templates
-        $template_directory = new \DirectoryIterator(\locate_template($dir));
+        $template_directory = new \DirectoryIterator($directory);
 
         foreach ($template_directory as $template) {
             if (!$template->isDot() && !$template->isDir()) {
@@ -55,7 +55,8 @@ add_action('acf/init', function () {
                 }
 
                 // Get header info from the found template file(s)
-                $file_path = locate_template($dir."/${slug}.blade.php");
+                $file = "${$directory}/${slug}.blade.php";
+                $file_path = file_exists($file) ? $file : '';
                 $file_headers = get_file_data($file_path, [
                     'title' => 'Title',
                     'description' => 'Description',
@@ -144,7 +145,6 @@ add_action('acf/init', function () {
  */
 function sage_blocks_callback($block, $content = '', $is_preview = false, $post_id = 0)
 {
-
     // Set up the slug to be useful
     $slug  = str_replace('acf/', '', $block['name']);
     $block = array_merge(['className' => ''], $block);
@@ -169,12 +169,22 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
     // Join up the classes.
     $block['classes'] = implode(' ', array_filter($block['classes']));
 
-    if (isSage10()) {
-        // Use Sage's view() function to echo the block and populate it with data
-        echo \Roots\view("blocks/${slug}", ['block' => $block]);
-    } else {
-        // Use Sage 9's template() function to echo the block and populate it with data
-        echo \App\template("blocks/${slug}", ['block' => $block]);
+    // Get the template directories.
+    $directories = apply_filters('sage-acf-gutenberg-blocks-templates', []);
+
+    foreach ($directories as $directory) {
+        if (isSage10()) {
+            $view = Str::replaceFirst('views/', '', $directory) . '/' . $slug;
+
+            if (\Roots\view()->exists($view)) {
+                // Use Sage's view() function to echo the block and populate it with data
+                echo \Roots\view($view, ['block' => $block]);
+            }
+
+        } else {
+            // Use Sage 9's template() function to echo the block and populate it with data
+            echo \App\template("{$directory}/${slug}", ['block' => $block]);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes the render callback issue when using a the filter 'sage-acf-gutenberg-blocks-templates' to add folder locations. Issue #45