### PR TITLE
Support new properties in ACF 5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Add blade templates to `views/blocks` which get and use ACF data. Each template 
 The options in the file header map to options in the [`acf_register_block_type`  function](https://www.advancedcustomfields.com/resources/acf_register_block_type/).
 
 | Field              | Description                                      | Values     | Notes |
-| ------------------ | ------------------------------------------------ | ---------- | ----  | 
+| ------------------ | ------------------------------------------------ | ---------- | ----  |
 | `Title`            | Title of the block in the gutenberg editor | i.e. `Testimonial` | _required_ |
-| `Description`      | Description of the block in the gutenberg editor | i.e. `My testimonial block` | _optional_ | 
+| `Description`      | Description of the block in the gutenberg editor | i.e. `My testimonial block` | _optional_ |
 | `Category`         | Category to store the block in. Use these values or [register your own custom block categories](https://wordpress.org/gutenberg/handbook/extensibility/extending-blocks/#managing-block-categories) | `common`, `formatting`, `layout`, `widgets`, `embed` | _required_ |
 | `Icon`             | An icon property can be specified to make it easier to identify a block. Uses [dashicons](https://developer.wordpress.org/resource/dashicons/) | i.e. `book-alt` | _optional_ |
 | `Keywords`         | An array of search terms to help user discover the block while searching. Sepearate values with a space. | i.e. `quote mention cite` | _optional_ |
@@ -79,7 +79,10 @@ The options in the file header map to options in the [`acf_register_block_type` 
 | `PostTypes`        | An array of post types to restrict this block type to. Sepearate values with a space. | i.e. `post page` |
 | `SupportsAlign`    | This property adds block controls which allow the user to change the block’s alignment. Set to true to show  all alignments, false to hide the alignment toolbar. Set to an array (strings separated by spaces) of specific alignment names to customize the toolbar. | (boolean) `true`, `false`<br> or (array) `left center right wide full` | _optional_ (defaults to true) |
 | `SupportsMode`     | This property allows the user to toggle between edit and preview modes via a button. | `true`  or `false` |_optional_ (defaults to `true`) |
-| `SupportsMultiple` |This property allows the block to be added multiple times. | `true`  or `false` |_optional_ (defaults to `true`) |
+| `SupportsMultiple` | This property allows the block to be added multiple times. | `true`  or `false` |_optional_ (defaults to `true`) |
+| `SupportsInnerBlocks` | This property allows the block to support the nesting of other blocks within it. | `true`  or `false` |_optional_ (defaults to `false`) |
+| `SupportsAlignText` | This property adds an alignment toolbar button similar to that seen when editing a paragraph of text. | `true`  or `false` |_optional_ (defaults to `false`) |
+| `SupportsAlignContent` | This property adds an alignment toolbar button similar to that seen when editing a core "Cover block" | `true`  or `false` |_optional_ (defaults to `false`) |
 
 ## Creating ACF fields
 Once a block is created you'll be able to assign ACF fields to it using the standard Custom Fields interface in WordPress. We recommend using [sage-advanced-custom-fields](https://github.com/MWDelaney/sage-advanced-custom-fields) to keep your ACF fields in version control with Sage.

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -68,6 +68,8 @@ add_action('acf/init', function () {
                     'supports_align' => 'SupportsAlign',
                     'supports_anchor' => 'SupportsAnchor',
                     'supports_mode' => 'SupportsMode',
+                    'supports_jsx' => 'SupportsInnerBlocks',
+                    'supports_align_text' => 'SupportsAlignText',
                     'supports_multiple' => 'SupportsMultiple',
                     'enqueue_style'     => 'EnqueueStyle',
                     'enqueue_script'    => 'EnqueueScript',
@@ -125,6 +127,16 @@ add_action('acf/init', function () {
                 // If the SupportsMode header is set in the template, restrict this block mode feature
                 if (!empty($file_headers['supports_mode'])) {
                     $data['supports']['mode'] = $file_headers['supports_mode'] === 'true' ? true : false;
+                }
+
+                // If the SupportsInnerBlocks header is set in the template, restrict this block mode feature
+                if (!empty($file_headers['supports_jsx'])) {
+                   $data['supports']['jsx'] = $file_headers['supports_jsx'] === 'true' ? true : false;
+                }
+
+                // If the SupportsInnerBlocks header is set in the template, restrict this block mode feature
+                if (!empty($file_headers['supports_align_text'])) {
+                   $data['supports']['align_text'] = $file_headers['supports_align_text'] === 'true' ? true : false;
                 }
 
                 // If the SupportsMultiple header is set in the template, restrict this block multiple feature

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -70,6 +70,7 @@ add_action('acf/init', function () {
                     'supports_mode' => 'SupportsMode',
                     'supports_jsx' => 'SupportsInnerBlocks',
                     'supports_align_text' => 'SupportsAlignText',
+                    'supports_align_content' => 'SupportsAlignContent',
                     'supports_multiple' => 'SupportsMultiple',
                     'enqueue_style'     => 'EnqueueStyle',
                     'enqueue_script'    => 'EnqueueScript',
@@ -134,9 +135,14 @@ add_action('acf/init', function () {
                    $data['supports']['jsx'] = $file_headers['supports_jsx'] === 'true' ? true : false;
                 }
 
-                // If the SupportsInnerBlocks header is set in the template, restrict this block mode feature
+                // If the SupportsAlignText header is set in the template, restrict this block mode feature
                 if (!empty($file_headers['supports_align_text'])) {
                    $data['supports']['align_text'] = $file_headers['supports_align_text'] === 'true' ? true : false;
+                }
+
+                // If the SupportsAlignContent header is set in the template, restrict this block mode feature
+                if (!empty($file_headers['supports_align_text'])) {
+                   $data['supports']['align_content'] = $file_headers['supports_align_content'] === 'true' ? true : false;
                 }
 
                 // If the SupportsMultiple header is set in the template, restrict this block multiple feature


### PR DESCRIPTION
This pull request includes the ability to use the new properties introduced in [ACF 5.9](https://www.advancedcustomfields.com/blog/acf-5-9-0-release-inner-blocks-ui-improvements-and-exciting-features/).

Specifically:
* Inner Blocks (`SupportsInnerBlocks`)
* Align Content (`SupportsAlignContent`)
* Align Text (`SupportsAlignText`)

I also updated the README to include these updates.