### PR TITLE
Fixed error in Sage9 with multiple block folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ add_filter('sage/blocks/my-block/data', function ($block) { // Do your thing her
 By default all your template files in `views/blocks` will be loaded. You can use the templates filter to add more folders if you wish. See an example below of how to add your own folders.
 
 ```php
-add_filter('sage-acf-gutenberg-blocks-templates', function ($folders) { 
-    $folders[] = 'views/your-folder'; // Adds your folder
+add_filter('sage-acf-gutenberg-blocks-other-templates', function ($folders) { 
+    $folders = ['views/your-folder', 'views/your-second-folder]; // Adds your folder
     return $folders;
 });
 ```


### PR DESCRIPTION
New feature with multiple folders in sage9 throw the critical error with wrong file paths.
Foreach loop for filter "sage-acf-gutenberg-blocks-templates" mixed wrong path with block files and return the error.
I've added new filter "sage-acf-gutenberg-blocks-other-templates" for other folders. This filter can be override in filters.php by new array. (readme updated with example). Default filter "sage-acf-gutenberg-blocks-templates" return only 'views/blocks' if developer not decide to use more block folders.

Not tested with sage10 but, the variable $view return the same result as before