### PR TITLE
fix: continue instead of return

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -35,7 +35,7 @@ add_action('acf/init', function () {
 
         // Sanity check whether the directory we're iterating over exists first
         if (!file_exists($dir)) {
-            return;
+            continue;
         }
 
         // Iterate over the directories provided and look for templates


### PR DESCRIPTION
`return` causes the entire function to end early if only one of many directories happens to not exist. Changing to `continue` gives other directories a chance of being scanned.